### PR TITLE
Incorrect size calculation fix

### DIFF
--- a/app/src/main/java/com/rajmani7584/payloaddumper/models/PayloadDumper.kt
+++ b/app/src/main/java/com/rajmani7584/payloaddumper/models/PayloadDumper.kt
@@ -31,7 +31,7 @@ object PayloadDumper {
             val partitions = payloadData[1].split(",").map { partition ->
                 val parts = partition.split("|")
                 if (largest.length < parts[0].length) largest = parts[0]
-                Partition(parts[0], parts[1].toFloatOrNull()?.div(1000) ?: 0f, parts[2])
+                Partition(parts[0], parts[1].toLongOrNull() ?: 0L, parts[2])
             }
             val incremental = payloadData[2] == "true"
             if (partitions.isEmpty()) return Result.failure(Error("Error: No Partition Found"))
@@ -75,4 +75,4 @@ class OnRustCallback(private val onProgress: (Long) -> Unit, private val onVerif
     }
 }
 data class Payload(val path: String, val name: String, val version: String, val patch: String, val partitions: List<Partition>, val incremental: Boolean, val largest: String)
-data class Partition(val name: String, val size: Float, val hash: String)
+data class Partition(val name: String, val size: Long, val hash: String)

--- a/app/src/main/java/com/rajmani7584/payloaddumper/models/Utils.kt
+++ b/app/src/main/java/com/rajmani7584/payloaddumper/models/Utils.kt
@@ -65,12 +65,14 @@ object Utils {
         }
     }
 
-    fun parseSize(size: Float): String {
-        return when (size) {
-            in 0f..1000f -> "%.2f KB".format(size)
-            in 1000f..1000000f -> "%.2f MB".format(size / 1000f)
-            in 1000000f..1000000000f -> "%.2f GB".format(size / 1000000f)
-            else -> "$size KB"
-        }
-    }
+    fun parseSize(bytes: Long): String = when {
+         bytes < 1024 ->
+          "$bytes B"
+         bytes < 1024L * 1024 ->
+          "%.2f KB".format(bytes / 1024.0)
+         bytes < 1024L * 1024 * 1024 ->
+          "%.2f MB".format(bytes / (1024.0 * 1024))
+    else ->
+          "%.2f GB".format(bytes / (1024.0 * 1024 * 1024))
+   }
 }


### PR DESCRIPTION
this pr fixes size parsing bug that was treating input as KB with decimal units (1000) instead of binary units (1024).
this caused sizes to display incorrectly - for ex. 1.60 GB would show as 1.72 GB

verified it builds after change:
https://github.com/rhythmcache/Payload-Dumper-Android/actions/runs/20302101724